### PR TITLE
Pr 1665

### DIFF
--- a/asmcomp/build_export_info.ml
+++ b/asmcomp/build_export_info.ml
@@ -569,8 +569,7 @@ let build_export_info ~(backend : (module Backend_intf.S))
           (Flambda_utils.all_sets_of_closures_map program)
       in
       let export = Compilenv.approx_env () in
-      Export_id.Map.fold (fun _eid (descr:Export_info.descr)
-                           (recursive) ->
+      Export_id.Map.fold (fun _eid (descr:Export_info.descr) recursive ->
           match descr with
           | Value_closure { set_of_closures }
           | Value_set_of_closures set_of_closures ->

--- a/middle_end/inlining_decision.ml
+++ b/middle_end/inlining_decision.ml
@@ -513,27 +513,27 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
       E.record_decision env decision;
       original, original_r
   | Some function_body ->
-  if function_body.stub then begin
-    let fun_vars = Variable.Map.keys function_decls.funs in
-    let body, r =
-      Inlining_transforms.inline_by_copying_function_body ~env
-        ~r ~fun_vars ~lhs_of_application
-        ~closure_id_being_applied ~specialise_requested ~inline_requested
-        ~function_decl ~function_body ~args ~dbg ~simplify
-    in
-    simplify env r body
-  end
-  else if E.never_inline env then
-    (* This case only occurs when examining the body of a stub function
-       but not in the context of inlining said function.  As such, there
-       is nothing to do here (and no decision to report). *)
-    original, original_r
-  else if function_decls.is_classic_mode then begin
-    let env =
-      E.note_entering_call env
-        ~closure_id:closure_id_being_applied ~dbg:dbg
-    in
-    let simpl =
+    if function_body.stub then begin
+      let fun_vars = Variable.Map.keys function_decls.funs in
+      let body, r =
+        Inlining_transforms.inline_by_copying_function_body ~env
+          ~r ~fun_vars ~lhs_of_application
+          ~closure_id_being_applied ~specialise_requested ~inline_requested
+          ~function_decl ~function_body ~args ~dbg ~simplify
+      in
+      simplify env r body
+    end
+    else if E.never_inline env then
+      (* This case only occurs when examining the body of a stub function
+         but not in the context of inlining said function.  As such, there
+         is nothing to do here (and no decision to report). *)
+      original, original_r
+    else if function_decls.is_classic_mode then begin
+      let env =
+        E.note_entering_call env
+          ~closure_id:closure_id_being_applied ~dbg:dbg
+      in
+      let simpl =
         let self_call =
           E.inside_set_of_closures_declaration
             function_decls.set_of_closures_origin env
@@ -543,9 +543,8 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
             Don't_try_it S.Not_inlined.Self_call
           else if not (E.inlining_allowed env closure_id_being_applied) then
             Don't_try_it S.Not_inlined.Unrolling_depth_exceeded
-          else begin
+          else
             Try_it
-          end
         in
         match try_inlining with
         | Don't_try_it decision -> Original decision
@@ -559,120 +558,122 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
           in
           let env = E.note_entering_inlined env in
           let env =
-            (* We decrement the unrolling count even if the function is not
-               recursive to avoid having to check whether or not it is recursive *)
+            (* We decrement the unrolling count even if the function is
+               not recursive to avoid having to check whether or not it
+               is recursive *)
             E.inside_unrolled_function env function_decls.set_of_closures_origin
           in
           let env = E.inside_inlined_function env closure_id_being_applied in
           Changed ((simplify env r body), S.Inlined.Classic_mode)
-    in
-    let res, decision =
-      match simpl with
-      | Original decision ->
-        let decision =
-          S.Decision.Unchanged (S.Not_specialised.Classic_mode, decision)
-        in
-        (original, original_r), decision
-      | Changed ((expr, r), decision) ->
-        let max_inlining_threshold =
-          if E.at_toplevel env then
-            Inline_and_simplify_aux.initial_inlining_toplevel_threshold
-              ~round:(E.round env)
-          else
-            Inline_and_simplify_aux.initial_inlining_threshold ~round:(E.round env)
-        in
-        let raw_inlining_threshold = R.inlining_threshold r in
-        let unthrottled_inlining_threshold =
-          match raw_inlining_threshold with
-          | None -> max_inlining_threshold
-          | Some inlining_threshold -> inlining_threshold
-        in
-        let inlining_threshold =
-          T.min unthrottled_inlining_threshold max_inlining_threshold
-        in
-        let inlining_threshold_diff =
-          T.sub unthrottled_inlining_threshold inlining_threshold
-        in
-        let res =
-          if E.inlining_level env = 0
-          then expr, R.set_inlining_threshold r raw_inlining_threshold
-          else expr, R.add_inlining_threshold r inlining_threshold_diff
-        in
-        res, S.Decision.Inlined (S.Not_specialised.Classic_mode, decision)
-    in
-    E.record_decision env decision;
-    res
-  end else begin
-    let env = E.unset_never_inline_inside_closures env in
-    let env =
-      E.note_entering_call env
-        ~closure_id:closure_id_being_applied ~dbg:dbg
-    in
-    let max_level =
-      Clflags.Int_arg_helper.get ~key:(E.round env) !Clflags.inline_max_depth
-    in
-    let raw_inlining_threshold = R.inlining_threshold r in
-    let max_inlining_threshold =
-      if E.at_toplevel env then
-        Inline_and_simplify_aux.initial_inlining_toplevel_threshold
-          ~round:(E.round env)
-      else
-        Inline_and_simplify_aux.initial_inlining_threshold ~round:(E.round env)
-    in
-    let unthrottled_inlining_threshold =
-      match raw_inlining_threshold with
-      | None -> max_inlining_threshold
-      | Some inlining_threshold -> inlining_threshold
-    in
-    let inlining_threshold =
-      T.min unthrottled_inlining_threshold max_inlining_threshold
-    in
-    let inlining_threshold_diff =
-      T.sub unthrottled_inlining_threshold inlining_threshold
-    in
-    let inlining_prevented =
-      match inlining_threshold with
-      | Never_inline -> true
-      | Can_inline_if_no_larger_than _ -> false
-    in
-    let simpl =
-      if inlining_prevented then
-        Original (D.Prevented Function_prevented_from_inlining)
-      else if E.inlining_level env >= max_level then
-        Original (D.Prevented Level_exceeded)
-      else begin
-        let self_call =
-          E.inside_set_of_closures_declaration
-            function_decls.set_of_closures_origin env
-        in
-        let fun_cost =
-          lazy
-            (Inlining_cost.can_try_inlining function_body.body
-                inlining_threshold
-                ~number_of_arguments:(List.length function_decl.params)
-                (* CR-someday mshinwell: for the moment, this is None, since
-                   the Inlining_cost code isn't checking sizes up to the max
-                   inlining threshold---this seems to take too long. *)
-                ~size_from_approximation:None)
-        in
-        let recursive =
-          lazy
-            (let fun_var = Closure_id.unwrap closure_id_being_applied in
-             Variable.Set.mem fun_var
-               (Lazy.force value_set_of_closures.recursive))
-        in
-        let specialise_result =
-          specialise env r
-            ~function_decls ~function_decl
-            ~lhs_of_application ~recursive ~closure_id_being_applied
-            ~value_set_of_closures ~args ~args_approxs ~dbg ~simplify
-            ~original ~inline_requested ~specialise_requested ~fun_cost
-            ~self_call ~inlining_threshold
-        in
-        match specialise_result with
-        | Changed (res, spec_reason) ->
-          Changed (res, D.Specialised spec_reason)
-        | Original spec_reason ->
+      in
+      let res, decision =
+        match simpl with
+        | Original decision ->
+          let decision =
+            S.Decision.Unchanged (S.Not_specialised.Classic_mode, decision)
+          in
+          (original, original_r), decision
+        | Changed ((expr, r), decision) ->
+          let max_inlining_threshold =
+            if E.at_toplevel env then
+              Inline_and_simplify_aux.initial_inlining_toplevel_threshold
+                ~round:(E.round env)
+            else
+              Inline_and_simplify_aux.initial_inlining_threshold
+                ~round:(E.round env)
+          in
+          let raw_inlining_threshold = R.inlining_threshold r in
+          let unthrottled_inlining_threshold =
+            match raw_inlining_threshold with
+            | None -> max_inlining_threshold
+            | Some inlining_threshold -> inlining_threshold
+          in
+          let inlining_threshold =
+            T.min unthrottled_inlining_threshold max_inlining_threshold
+          in
+          let inlining_threshold_diff =
+            T.sub unthrottled_inlining_threshold inlining_threshold
+          in
+          let res =
+            if E.inlining_level env = 0
+            then expr, R.set_inlining_threshold r raw_inlining_threshold
+            else expr, R.add_inlining_threshold r inlining_threshold_diff
+          in
+          res, S.Decision.Inlined (S.Not_specialised.Classic_mode, decision)
+      in
+      E.record_decision env decision;
+      res
+    end else begin
+      let env = E.unset_never_inline_inside_closures env in
+      let env =
+        E.note_entering_call env
+          ~closure_id:closure_id_being_applied ~dbg:dbg
+      in
+      let max_level =
+        Clflags.Int_arg_helper.get ~key:(E.round env) !Clflags.inline_max_depth
+      in
+      let raw_inlining_threshold = R.inlining_threshold r in
+      let max_inlining_threshold =
+        if E.at_toplevel env then
+          Inline_and_simplify_aux.initial_inlining_toplevel_threshold
+            ~round:(E.round env)
+        else
+          Inline_and_simplify_aux.initial_inlining_threshold ~round:(E.round env)
+      in
+      let unthrottled_inlining_threshold =
+        match raw_inlining_threshold with
+        | None -> max_inlining_threshold
+        | Some inlining_threshold -> inlining_threshold
+      in
+      let inlining_threshold =
+        T.min unthrottled_inlining_threshold max_inlining_threshold
+      in
+      let inlining_threshold_diff =
+        T.sub unthrottled_inlining_threshold inlining_threshold
+      in
+      let inlining_prevented =
+        match inlining_threshold with
+        | Never_inline -> true
+        | Can_inline_if_no_larger_than _ -> false
+      in
+      let simpl =
+        if inlining_prevented then
+          Original (D.Prevented Function_prevented_from_inlining)
+        else if E.inlining_level env >= max_level then
+          Original (D.Prevented Level_exceeded)
+        else begin
+          let self_call =
+            E.inside_set_of_closures_declaration
+              function_decls.set_of_closures_origin env
+          in
+          let fun_cost =
+            lazy
+              (Inlining_cost.can_try_inlining function_body.body
+                 inlining_threshold
+                 ~number_of_arguments:(List.length function_decl.params)
+                 (* CR-someday mshinwell: for the moment, this is None, since
+                    the Inlining_cost code isn't checking sizes up to the max
+                    inlining threshold---this seems to take too long. *)
+                 ~size_from_approximation:None)
+          in
+          let recursive =
+            lazy
+              (let fun_var = Closure_id.unwrap closure_id_being_applied in
+               Variable.Set.mem fun_var
+                 (Lazy.force value_set_of_closures.recursive))
+          in
+          let specialise_result =
+            specialise env r
+              ~function_decls ~function_decl
+              ~lhs_of_application ~recursive ~closure_id_being_applied
+              ~value_set_of_closures ~args ~args_approxs ~dbg ~simplify
+              ~original ~inline_requested ~specialise_requested ~fun_cost
+              ~self_call ~inlining_threshold
+          in
+          match specialise_result with
+          | Changed (res, spec_reason) ->
+            Changed (res, D.Specialised spec_reason)
+          | Original spec_reason ->
             let only_use_of_function = false in
             (* If we didn't specialise then try inlining *)
             let size_from_approximation =
@@ -705,22 +706,22 @@ let for_call_site ~env ~r ~(function_decls : A.function_declarations)
               Changed (res, D.Inlined (spec_reason, inl_reason))
             | Original inl_reason ->
               Original (D.Unchanged (spec_reason, inl_reason))
-      end
-    in
-    let res, decision =
-      match simpl with
-      | Original decision -> (original, original_r), decision
-      | Changed ((expr, r), decision) ->
-        let res =
-          if E.inlining_level env = 0
-          then expr, R.set_inlining_threshold r raw_inlining_threshold
-          else expr, R.add_inlining_threshold r inlining_threshold_diff
-        in
-        res, decision
-    in
-    E.record_decision env decision;
-    res
-  end
+        end
+      in
+      let res, decision =
+        match simpl with
+        | Original decision -> (original, original_r), decision
+        | Changed ((expr, r), decision) ->
+          let res =
+            if E.inlining_level env = 0
+            then expr, R.set_inlining_threshold r raw_inlining_threshold
+            else expr, R.add_inlining_threshold r inlining_threshold_diff
+          in
+          res, decision
+      in
+      E.record_decision env decision;
+      res
+    end
 
 (* We do not inline inside stubs, which are always inlined at their call site.
    Inlining inside the declaration of a stub could result in more code than

--- a/middle_end/inlining_transforms.ml
+++ b/middle_end/inlining_transforms.ml
@@ -99,7 +99,7 @@ let inline_by_copying_function_body ~env ~r
   assert (E.mem env lhs_of_application);
   assert (List.for_all (E.mem env) args);
   let r =
-    if function_decl.stub then r
+    if function_body.stub then r
     else R.map_benefit r B.remove_call
   in
   let freshened_params, body =
@@ -107,7 +107,7 @@ let inline_by_copying_function_body ~env ~r
       ~function_decl ~function_body
   in
   let body =
-    if function_decl.stub &&
+    if function_body.stub &&
        ((inline_requested <> Lambda.Default_inline)
         || (specialise_requested <> Lambda.Default_specialise)) then
       (* When the function inlined function is a stub, the annotation
@@ -526,11 +526,11 @@ let rewrite_function ~lhs_of_application ~closure_id_being_applied
   let new_function_decl =
     Flambda.create_function_declaration
       ~params ~body
-      ~stub:function_decl.stub
-      ~dbg:function_decl.dbg
-      ~inline:function_decl.inline
-      ~specialise:function_decl.specialise
-      ~is_a_functor:function_decl.is_a_functor
+      ~stub:function_body.stub
+      ~dbg:function_body.dbg
+      ~inline:function_body.inline
+      ~specialise:function_body.specialise
+      ~is_a_functor:function_body.is_a_functor
   in
   let new_funs =
     Variable.Map.add new_fun_var new_function_decl state.new_funs

--- a/middle_end/simple_value_approx.mli
+++ b/middle_end/simple_value_approx.mli
@@ -153,17 +153,17 @@ and function_declarations = private {
 and function_body = private {
   free_variables : Variable.Set.t;
   free_symbols : Symbol.Set.t;
-  body : Flambda.t;
-}
-
-and function_declaration = private {
-  function_body : function_body option;
-  params : Parameter.t list;
   stub : bool;
   dbg : Debuginfo.t;
   inline : Lambda.inline_attribute;
   specialise : Lambda.specialise_attribute;
   is_a_functor : bool;
+  body : Flambda.t;
+}
+
+and function_declaration = private {
+  params : Parameter.t list;
+  function_body : function_body option;
 }
 
 
@@ -224,7 +224,7 @@ val function_declarations_approx
 val create_value_set_of_closures
    : function_decls:function_declarations
   -> bound_vars:t Var_within_closure.Map.t
-  -> free_vars: Flambda.specialised_to Variable.Map.t
+  -> free_vars:Flambda.specialised_to Variable.Map.t
   -> invariant_params:Variable.Set.t Variable.Map.t lazy_t
   -> recursive:Variable.Set.t Lazy.t
   -> specialised_args:Flambda.specialised_to Variable.Map.t


### PR DESCRIPTION
I mainly moved a few fields from function_decl to function_body because they are useless when the body is absent. This allows a bit of refactoring that eliminates some `assert false` and gain a few bytes per closures.

There is a second indentation patch. You should probably discard it right now and apply (or redo) it after 1666.